### PR TITLE
fix: deploy-storacha.yml needs to use the new main branch

### DIFF
--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -2,18 +2,115 @@ name: Deploy Storacha
 on:
   push:
     branches:
-      - 'feat/storacha-skin'
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  preview:
+    name: Preview
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    environment:
+      name: ${{ (github.ref_name == 'main') && 'staging' || format('preview-{0}', github.ref_name) }}
+      url: ${{ (github.ref_name == 'main') && 'https://staging.console.web3.storage/' || steps.cloudflare_url.outputs.stdout }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - name: create .env from .env.tpl setting env variables used by `pnpm run pages:build`
+        run: |
+          # set env vars from template
+
+          # omit these because they are added manually in the next step          
+          function excludeDefaultServiceVariables() {
+            cat - | grep -v NEXT_PUBLIC_W3UP_SERVICE_ | grep -v NEXT_PUBLIC_STRIPE
+          }
+
+          # set .env from .env.tpl with exclusions
+          cat .env.tpl | excludeDefaultServiceVariables > .env
+
+          # add vars configuring console frontend to use staging w3up as backend
+          echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
+          echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
+          echo "NEXT_PUBLIC_STRIPE_CUSTOMER_PORTAL_LINK=https://billing.stripe.com/p/login/test_6oE29Gff99KO6mk8ww" >> .env
+      # as long as this uses https://github.com/cloudflare/next-on-pages/blob/dc529d7efa8f8568ea8f71b5cdcf78df89be6c12/packages/next-on-pages/bin/index.js,
+      # env vars won't get passed through to wrangler, so if wrangler will need them, write them to .env like the previous step
+      - run: pnpm pages:build
+      - name: Deploy preview build to Cloudflare Pages
+        uses: mathiasvr/command-output@v1.1.0
+        id: cloudflare
+        with:
+          run: npx wrangler pages deploy --project-name "$CLOUDFLARE_PAGES_PROJECT_NAME" --branch "$GITHUB_REF_NAME" --commit-hash "$GITHUB_SHA" .vercel/output/static
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_PAGES_PROJECT_NAME: ${{ (github.ref_name == 'main') && 'console-web3-storage-staging' || 'console-web3-storage-preview' }}
+      - name: Find Cloudflare Pages preview URL
+        uses: mathiasvr/command-output@v1.1.0
+        id: cloudflare_url
+        with:
+          run: egrep -o 'https?://[^ ]+' <(echo "${{ steps.cloudflare.outputs.stdout }}")
+      - name: Find Current Pull Request
+        uses: jwalton/gh-find-current-pr@v1.3.0
+        id: finder
+      - name: Update Preview URLs PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          number: ${{ steps.finder.outputs.pr }}
+          message: |
+            ### Website preview 🔗✨
+            - ⛅️ ${{ steps.cloudflare_url.outputs.stdout }}
+
+            [build log](/${{ github.repository }}/actions/runs/${{ github.run_id }})
+      - name: Add Preview URLs as Job Summary
+        run: |
+          echo "
+          ### Website preview 🔗✨
+            - ⛅️ ${{ steps.cloudflare_url.outputs.stdout }}
+
+            [build log](/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+  
+  changelog:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.tag-release.outputs.releases_created }}
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        id: tag-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          monorepo-tags: true
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+
   release:
     name: Release
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
     runs-on: ubuntu-latest
     environment:
       name: production
       url: https://console.storacha.network
+    needs:
+      - test
+      - changelog
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: 'feat/storacha-skin'
+          ref: 'main'
       - uses: ./.github/actions/pnpm
       - name: create .env from .env.tpl setting env variables used by `pnpm run pages:build`
         run: |


### PR DESCRIPTION
I've fixed the `deploy-storacha.yml` workflow to build previews and changelogs, run tests, and create releases using the same conditionals we had while deploying to `https://console.web3.storage`.