### PR TITLE
fix: add missing receiptsEndpoint to W3UIProvider

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,5 +1,6 @@
 # set these to your upload API service URL and the DID your service is using as its service DID
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage
+NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage
 NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage
 

--- a/.env.tpl
+++ b/.env.tpl
@@ -1,6 +1,6 @@
 # set these to your upload API service URL and the DID your service is using as its service DID
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage
-NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt
+NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt/
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage
 NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage
 

--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -38,6 +38,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.storacha.network" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -127,6 +128,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -38,7 +38,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.storacha.network" >> .env
-          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -128,7 +128,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
-          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -126,7 +126,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -125,6 +126,7 @@ jobs:
           # add vars configuring console frontend to use staging w3up as backend
           echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, this app connects to `https://up.web3.storage`, and uses `did:web:we
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://your.w3up.service
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:your-service-did
 NEXT_PUBLIC_W3UP_PROVIDER=did:your-provider-did
-NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://your.w3up.service/receipt
+NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://your.w3up.service/receipt/
 ```
 
 An example `.env.local` file can be found in `.env.tpl`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ By default, this app connects to `https://up.web3.storage`, and uses `did:web:we
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://your.w3up.service
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:your-service-did
 NEXT_PUBLIC_W3UP_PROVIDER=did:your-provider-did
+NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://your.w3up.service/receipt
 ```
 
 An example `.env.local` file can be found in `.env.tpl`.

--- a/src/components/W3UIProvider.tsx
+++ b/src/components/W3UIProvider.tsx
@@ -1,12 +1,16 @@
 'use client'
 import { Provider } from '@w3ui/react'
-import { serviceConnection, servicePrincipal } from '@/components/services'
+import { serviceConnection, servicePrincipal, receiptsURL } from '@/components/services'
 import { ReactNode } from 'react'
 
 
 export default function W3UIProvider ({ children }: { children: ReactNode }) {
   return (
-    <Provider connection={serviceConnection} servicePrincipal={servicePrincipal}>
+    <Provider
+      connection={serviceConnection}
+      servicePrincipal={servicePrincipal}
+      receiptsEndpoint={receiptsURL}
+    >
       <>{children}</>
     </Provider>
   )

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -8,6 +8,12 @@ export const serviceURL = new URL(
   // 'https://staging.up.web3.storage'
   process.env.NEXT_PUBLIC_W3UP_SERVICE_URL ?? 'https://up.web3.storage'
 )
+
+export const receiptsURL = new URL(
+  // 'https://staging.up.web3.storage/receipt'
+  process.env.NEXT_PUBLIC_W3UP_RECEIPTS_URL ?? 'https://up.web3.storage/receipt'
+)
+
 export const servicePrincipal = DID.parse(
   // 'did:web:staging.web3.storage'
   process.env.NEXT_PUBLIC_W3UP_SERVICE_DID ?? 'did:web:web3.storage'

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -10,8 +10,8 @@ export const serviceURL = new URL(
 )
 
 export const receiptsURL = new URL(
-  // 'https://staging.up.web3.storage/receipt'
-  process.env.NEXT_PUBLIC_W3UP_RECEIPTS_URL ?? 'https://up.web3.storage/receipt'
+  // 'https://staging.up.web3.storage/receipt/'
+  process.env.NEXT_PUBLIC_W3UP_RECEIPTS_URL ?? 'https://up.web3.storage/receipt/'
 )
 
 export const servicePrincipal = DID.parse(


### PR DESCRIPTION
## Description

This PR adds a `receiptsEndpoint` configuration to `W3UIProvider`. The receipts URL is currently not provided by the console to the client as an option, so this ensures the endpoint is explicitly configured.

## Motivation
Uploading in staging is currently broken. The console shows an error when attempting to retrieve the receipt.

The receipts endpoint being used for staging is incorrect due to a missing configuration. This causes the value to default to a hardcoded production endpoint.