### PR TITLE
enhance: Add reset button for error state in Uploader

### DIFF
--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -63,6 +63,8 @@ export const Uploading = ({
 )
 
 export const Errored = ({ error }: { error: any }): JSX.Element => {
+  const [, { setFile }] = useUploader()
+
   useEffect(() => {
     if (error != null) {
       // eslint-disable-next-line no-console
@@ -76,6 +78,16 @@ export const Errored = ({ error }: { error: any }): JSX.Element => {
         ⚠️ Error: failed to upload file: {error.message}
       </h1>
       <p>Check the browser console for details.</p>
+      <div className='my-4'>
+      <button
+          className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap'
+          onClick={() => {
+            setFile(undefined)
+          }}
+        >
+          Reset uploading file
+        </button>
+      </div>
     </div>)
   );
 }


### PR DESCRIPTION
### Description

- Currently, in `Uploader` component doesn't have handling on uploading file is error. The error will make user flow stuck and in order to reupload a file (or choosing another file), user needs to refresh the page
<img width="1368" alt="Screenshot 2567-12-04 at 11 00 45" src="https://github.com/user-attachments/assets/c61ae1b1-ceda-448c-93b2-af61dc5f23bf">

- Based on interface of `useUpload` from `@w3ui/react`, we can add button for clear uploading files in order to back to `idle` state. Here is result after adding the button
https://github.com/user-attachments/assets/6bb8a67b-7c45-4ef7-809c-a24e69397159

Note:
- I'm not sure on wording for this button, suggestions are welcome