### PR TITLE
fix: make it possible to skip the plan gate after Stripe checkout

### DIFF
--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -7,6 +7,7 @@ import { TopLevelLoader } from './Loader';
 import { Logo } from '@/brand';
 import { usePlan } from '@/hooks';
 import { useRecordRefcode, useReferredBy } from '@/lib/referrals/hooks';
+import { useSearchParams } from 'next/navigation';
 
 export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
   const [{ accounts }] = useW3()
@@ -64,7 +65,8 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
 }
 
 export function MaybePlanGate ({ children }: { children: ReactNode }): ReactNode {
-  if (process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') {
+  const params = useSearchParams()
+  if ((process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') || (params.get('checkout') === 'true')) {
     return children
   } else {
     return <PlanGate>{children}</PlanGate>


### PR DESCRIPTION
we really don't want to show the plan gate if we just finished Stripe checkout - sometimes Stripe isn't fast enough with the webhook so this will help us provide a UX that makes sense even in this case