### PR TITLE
fix: tweak plan gate query param

### DIFF
--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -7,6 +7,7 @@ import { TopLevelLoader } from './Loader';
 import { Logo } from '@/brand';
 import { usePlan } from '@/hooks';
 import { useRecordRefcode, useReferredBy } from '@/lib/referrals/hooks';
+import { useSearchParams } from 'next/navigation';
 
 export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
   const [{ accounts }] = useW3()
@@ -64,7 +65,8 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
 }
 
 export function MaybePlanGate ({ children }: { children: ReactNode }): ReactNode {
-  if (process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') {
+  const params = useSearchParams()
+  if ((process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') || (params.get('checkout') === 'true')) {
     return children
   } else {
     return <PlanGate>{children}</PlanGate>

--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -66,7 +66,7 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
 
 export function MaybePlanGate ({ children }: { children: ReactNode }): ReactNode {
   const params = useSearchParams()
-  if ((process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') || (params.get('checkout') === 'true')) {
+  if ((process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') || params.get('checkout.session')) {
     return children
   } else {
     return <PlanGate>{children}</PlanGate>


### PR DESCRIPTION
it turns out Stripe already adds the `checkout.session` query param to this URL - this means we don't even need to update Stripe to fix this!