### PR TITLE
feat: enable Sentry replay

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -8,6 +8,13 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV,
 
+  integrations: [
+    Sentry.replayIntegration(),
+  ],
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 


### PR DESCRIPTION
Enable session replay in Sentry.

I want to propose this separate from other changes because it could be controversial! Sentry is not a session recording, but it's not far from one and I'd like to make sure everyone understands what it will do before we integrate it. Details here:

https://docs.sentry.io/product/explore/session-replay/web/