### PR TITLE
fix: create space

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ucanto/core": "^10.0.1",
     "@ucanto/interface": "^10.0.1",
     "@ucanto/transport": "^9.1.1",
-    "@w3ui/react": "2.5.3",
+    "@w3ui/react": "2.5.4",
     "@web3-storage/access": "^19.0.0",
     "@web3-storage/capabilities": "^17.3.0",
     "@web3-storage/content-claims": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^9.1.1
         version: 9.1.1
       '@w3ui/react':
-        specifier: 2.5.3
-        version: 2.5.3(@types/react@18.2.42)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 2.5.4
+        version: 2.5.4(@types/react@18.2.42)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@web3-storage/access':
         specifier: ^19.0.0
         version: 19.0.0
@@ -1154,8 +1154,8 @@ packages:
   '@storacha/capabilities@1.2.0':
     resolution: {integrity: sha512-xnVCzZFALIrybbiEpdRg5FCA7HAnxsfJ7yWDOu1YDqWfvA5iBhG4jVM4ocGJ/bD65ov7KG0vP96tPnjprp4pKg==}
 
-  '@storacha/client@1.1.1':
-    resolution: {integrity: sha512-677TMJVFohDAjtE8J0IcjT6VubFoYYkrAKTHJfhBE8wU+dRlKsCPN+eyN9oz7EM9mtqICFgtCgBA0021vgRqjQ==}
+  '@storacha/client@1.1.2':
+    resolution: {integrity: sha512-zZiWCpUQy4kKEt4j2PR9wvsLlP9tr9T6MV+Kx+sh29EuRUCZhS2tjwShVajk79rQU0qv0tNDP2x3+4YSWDsjhg==}
     engines: {node: '>=18'}
 
   '@storacha/did-mailto@1.0.1':
@@ -1408,11 +1408,11 @@ packages:
   '@vercel/static-config@3.0.0':
     resolution: {integrity: sha512-2qtvcBJ1bGY0dYGYh3iM7yGKkk971FujLEDXzuW5wcZsPr1GSEjO/w2iSr3qve6nDDtBImsGoDEnus5FI4+fIw==}
 
-  '@w3ui/core@2.4.1':
-    resolution: {integrity: sha512-7lXfA7rkoF16/jAUUvk4zKunHE/1VgLjEj+0pRcP8SJianhiUI57xtpImmltoyaI+y0O4vIfHFHkX2pBjqo33Q==}
+  '@w3ui/core@2.4.2':
+    resolution: {integrity: sha512-6pKDjqTcZBS9KzKtlJKtsOyru/YC1XWync2XFBaKnIUkzzvM/xpQUrCzpt2O2MHgK8Z+JrF/b4u6oUutTjdNTQ==}
 
-  '@w3ui/react@2.5.3':
-    resolution: {integrity: sha512-2ygPPG0KKMq3cnB0f1AcObsUWW1b55fiJ3/ENqIeQX0t1gyK/jru2R+HFW7NmhjqnzRFQ8/HloF4xQqyeDRLAQ==}
+  '@w3ui/react@2.5.4':
+    resolution: {integrity: sha512-aZAooYYxtsYiSDOLSvcU2sLZtcawX8NEmU5CC//SIjlBfWjEOrpptM07/qiz+ZqWb+oyqqRn1QPEvU8tyZrKhg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -5906,7 +5906,7 @@ snapshots:
       '@web3-storage/data-segment': 5.2.0
       uint8arrays: 5.1.0
 
-  '@storacha/client@1.1.1(encoding@0.1.13)':
+  '@storacha/client@1.1.2(encoding@0.1.13)':
     dependencies:
       '@ipld/dag-ucan': 3.4.0
       '@storacha/access': 1.0.0
@@ -6334,10 +6334,10 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@w3ui/core@2.4.1(encoding@0.1.13)':
+  '@w3ui/core@2.4.2(encoding@0.1.13)':
     dependencies:
       '@ipld/dag-ucan': 3.4.0
-      '@storacha/client': 1.1.1(encoding@0.1.13)
+      '@storacha/client': 1.1.2(encoding@0.1.13)
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.0.1
       '@ucanto/principal': 9.0.1
@@ -6347,11 +6347,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@w3ui/react@2.5.3(@types/react@18.2.42)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@w3ui/react@2.5.4(@types/react@18.2.42)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@ariakit/react-core': 0.3.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@w3ui/core': 2.4.1(encoding@0.1.13)
+      '@w3ui/core': 2.4.2(encoding@0.1.13)
       ariakit-react-utils: 0.17.0-next.27(@types/react@18.2.42)(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:


### PR DESCRIPTION
Update the `w3ui-react` lib to the latest version, so we can use the `w3up-client` fix that saves the new space to grant access to the agent.
![image](https://github.com/user-attachments/assets/6aa6b09b-ee14-426d-b3fd-1003f49c80fa)
