### PR TITLE
fix: gateway authorization based on env

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -4,6 +4,10 @@ NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt/
 NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage
 NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage
 
+# set these to your gateway service URL and DID 
+NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus
+NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link
+
 # set these to values from Stripe settings
 NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCeiEF6A5ufQX5vPFlWRkPm
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC

--- a/.env.tpl
+++ b/.env.tpl
@@ -5,7 +5,7 @@ NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage
 NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage
 
 # set these to your gateway service URL and DID 
-NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus
+NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway-staging.dag.haus
 NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link
 
 # set these to values from Stripe settings

--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -40,7 +40,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway-staging.dag.haus" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_TRIAL_PRICING_TABLE_ID=prctbl_1QIDHGF6A5ufQX5vOK9Xl8Up" >> .env
@@ -137,7 +137,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://w3s.link" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_TRIAL_PRICING_TABLE_ID=prctbl_1QPYsuF6A5ufQX5vdIGAe54g" >> .env

--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -40,6 +40,8 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_TRIAL_PRICING_TABLE_ID=prctbl_1QIDHGF6A5ufQX5vOK9Xl8Up" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -135,6 +137,8 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_TRIAL_PRICING_TABLE_ID=prctbl_1QPYsuF6A5ufQX5vdIGAe54g" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
           echo "NEXT_PUBLIC_STRIPE_CUSTOMER_PORTAL_LINK=https://billing.stripe.com/p/login/test_6oE29Gff99KO6mk8ww" >> .env
@@ -128,6 +130,8 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env
           echo "NEXT_PUBLIC_STRIPE_CUSTOMER_PORTAL_LINK=https://billing.stripe.com/p/login/cN22aA62U6bO1sA9AA" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway-staging.dag.haus" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
@@ -130,7 +130,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://w3s.link" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env
           echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51LO87hF6A5ufQX5vQTO5BHyz8y9ybJp4kg1GsBjYuqwluuwtQTkbeZzkoQweFQDlv7JaGjuIdUWAyuwXp3tmCfsM005lJK9aS8" >> .env

--- a/src/components/SpaceCreator.tsx
+++ b/src/components/SpaceCreator.tsx
@@ -60,7 +60,7 @@ export function SpaceCreatorForm({
     try {
 
       const gatewayId = toWebDID(process.env.NEXT_PUBLIC_W3UP_GATEWAY_ID) || toWebDID('did:web:w3s.link')
-      const gatewayUrl = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST || 'https://freeway.dag.haus'
+      const gatewayUrl = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST || 'https://w3s.link'
 
       const storachaGateway = UcantoClient.connect({
         id: {


### PR DESCRIPTION
In order to create new spaces in `Staging` or `localhost` environments we need to configure the w3up-client to authorize the correct gateway service, otherwise, it will default to the Production Storacha Gateway.
This PR implements the logic to create the gateway connection based on the environment variables and passes that connection to the `w3up-client.createSpace` call, so the correct service is authorized.