### PR TITLE
fix: cors preflight issue in production

### DIFF
--- a/.github/workflows/deploy-storacha.yml
+++ b/.github/workflows/deploy-storacha.yml
@@ -138,7 +138,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://w3s.link" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_IPFS_GATEWAY_URL=https://%ROOT_CID%.ipfs.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.web3.storage/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://w3s.link" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://freeway.dag.haus" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_IPFS_GATEWAY_URL=https://%ROOT_CID%.ipfs.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -33,4 +33,9 @@ export const serviceConnection = connect<Service>({
   }),
 })
 
-export const gatewayHost = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST ?? 'https://w3s.link'
+/**
+ * Using freeway.dag.haus/freeway-staging.dag.haus as the gateway host directly without going through w3s.link
+ * to avoid the need to avoid access fetch error in production due to the w3s.link CORS policy:
+ * - Redirect is not allowed for a preflight request.
+ */
+export const gatewayHost = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST ?? 'https://freeway.dag.haus'


### PR DESCRIPTION
### Context
- Error while creating a new space in production:
> create:1 Access to fetch at 'https://w3s.link/' from origin 'https://console.storacha.network' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a preflight request.

### Issue
- I was using the `w3s.link` as the gateway host to be authorized to serve the space content, but the cors policy defined in the `w3s.link` doesn't allow redirects for a preflight request. 
- It doesn't happen in staging because in staging I am using the actual gateway, and not the proxy: `freeway-staging.dag.haus`.

### Fix
- Authorize the actual production gateway instead of the proxy: `https://freeway.dag.haus`.