### PR TITLE
fix: typo on space page

### DIFF
--- a/src/app/space/create/page.tsx
+++ b/src/app/space/create/page.tsx
@@ -13,7 +13,7 @@ export default function CreateSpacePage (): JSX.Element {
         <SpaceCreatorForm className='mb-8' />
         <H2>Explain</H2>
         <p className='font-epilogue'>
-          A space is decentralized bucket. The name you give it is a memorable alias.
+          A space is a decentralized bucket. The name you give it is a memorable alias.
         </p>
         <p className='font-epilogue'>
           It&apos;s true name is a unique DID derived from a key-pair.


### PR DESCRIPTION
nitpick [non-blocking]:

Add an a.
A space is [a] decentralized bucket.

See image for original.
<img width="294" alt="image" src="https://github.com/user-attachments/assets/d9e1642f-2fae-4962-9eb5-ed338571c5de" />
